### PR TITLE
Accept arguments and add them as data-attributes

### DIFF
--- a/dom-builder.js
+++ b/dom-builder.js
@@ -35,9 +35,16 @@ DOMBuilder.prototype.ele = function (tag, arg2, arg3) {
 	this.body = this.body.concat('<'+tag);
 
 	if (typeof arg2 == 'object') {
-		for (var attr in arg2) {
-			this.body = this.body.concat(' '+attr+'='+'"'+arg2[attr]+'"');
-		}
+		for (let attr in arg2) {
+            if(attr === 'data'){
+                for(let dataAttr of Object.keys(arg2.data)){
+                    this.body = this.body.concat(' data-'+dataAttr+'='+'"'+arg2.data[dataAttr]+'"');
+                }
+            }
+            else {
+                this.body = this.body.concat(' '+attr+'='+'"'+arg2[attr]+'"');
+            }
+        }
 	}
 
 	if (this.SELF_CLOSING_TAGS.indexOf(tag) == -1) {


### PR DESCRIPTION
hi, i loved the library you wrote XD i'm doing a coding excercise with it,

i found myself with the issue of adding data-toogle and data-modal attributes to a button tag, and i think is not supported yet, so i took the liberty to extend it. this way we can pass an object data :
{ foo: 'value1', bar:'value2' } as arg2 and will render data-foo="value1" data-bar="value2", etc. etc.

i know is not fully tested, but i think it would be a great addition, let me know what you think.

Regards 
Carlos Bolanos